### PR TITLE
chore(dockerfile): update node image to lts-buster (#557)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
 # build frontend
-FROM node:lts-alpine3.12 AS fe-builder
+FROM node:lts-buster AS fe-builder
 
 COPY ./assets /assets
 
 WORKDIR /assets
 
+# yarn repo connection is unstable, adjust the network timeout to 10 min.
 RUN set -ex \
-    && apk upgrade \
-    && yarn install \
+    && yarn install --network-timeout 600000 \
     && yarn run build
 
 # build backend
-FROM golang:1.15.0-alpine3.12 AS be-builder
+FROM golang:1.15.1-alpine3.12 AS be-builder
 
 ENV GO111MODULE on
 
@@ -36,11 +36,30 @@ FROM alpine:3.12 AS dist
 
 LABEL maintainer="mritd <mritd@linux.com>"
 
+# we use the Asia/Shanghai timezone by default, you can be modified
+# by `docker build --build-arg=TZ=Other_Timezone ...`
+ARG TZ="Asia/Shanghai"
+
+ENV TZ ${TZ}
+
 COPY --from=be-builder /go/bin/cloudreve /cloudreve/cloudreve
 
 RUN apk upgrade \
     && apk add bash tzdata \
     && ln -s /cloudreve/cloudreve /usr/bin/cloudreve \
+    && ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime \
+    && echo ${TZ} > /etc/timezone \
     && rm -rf /var/cache/apk/*
+
+# cloudreve use tcp 5212 port by default
+EXPOSE 5212/tcp
+
+# cloudreve stores all files(including executable file) in the `/cloudreve`
+# directory by default; users should mount the configfile to the `/etc/cloudreve`
+# directory by themselves for persistence considerations, and the data storage
+# directory recommends using `/data` directory.
+VOLUME /etc/cloudreve
+
+VOLUME /data
 
 ENTRYPOINT ["cloudreve"]


### PR DESCRIPTION
* chore(dockerfile): update node image to lts-buster

update node image to lts-buster, because the alpine image cannot be obtained on arm/arm64,
it will support `docker buildx` build after the upgrade.

Signed-off-by: mritd <mritd@linux.com>

* chore(docker): update golang build image

update golang build image

Signed-off-by: mritd <mritd@linux.com>